### PR TITLE
Use pkgdown on top of a base layer of r2u for more reliable package installation

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -28,15 +28,27 @@ jobs:
 
       - uses: r-lib/actions/setup-pandoc@v2
 
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          use-public-rspm: true
+      #- uses: r-lib/actions/setup-r@v2
+      #  with:
+      #    use-public-rspm: true
 
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: any::pkgdown, local::.
-          needs: website
+      #- uses: r-lib/actions/setup-r-dependencies@v2
+      #  with:
+      #    extra-packages: any::pkgdown, local::.
+      #    needs: website
 
+      - name: Setup r2u
+        uses: eddelbuettel/github-actions/r2u-setup@master
+        
+      - name: Install remotes and pkgdown
+        run: Rscript -e 'install.packages(c("remotes", "pkgdown"))'
+        
+      - name: Install all Dependencies 
+        run: Rscript -e 'remotes::install_deps(".", dependencies=TRUE)'
+
+      - name: Install package itself
+        run: R CMD INSTALL .
+          
       - name: Build site
         run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
         shell: Rscript {0}


### PR DESCRIPTION
This PR comments-out two setup steps which currently fail for you, and replaces with a base layer of [r2u](https://eddelbuettel.github.io/r2u) via a setup action for it, and then use it for `remotes` and `pkgdown` as well as all dependencies.  We can then install the package, and call `pkgdown` as before and commit the result as before.

It worked in my fork (minus the commit as I have not PAT), should work for you too.

