### PR TITLE
mvscale optionally returns center and scaling terms

### DIFF
--- a/R/mvscale.R
+++ b/R/mvscale.R
@@ -26,6 +26,9 @@
 #' @param cov A function to compute the covariance matrix. Set to NULL if no rotation required. `cov()` must either return the matrix directly, or a list containing a matrix named `cov`.
 #' @param alpha When `cov = robustbase::covMcd()`, `alpha` controls the size of the subsets over which the determinant is minimized. Otherwise it is ignored. Set to 0.9 by default.
 #' @param warning Should a warning be issued if non-numeric columns are ignored?
+#' @param what What to return? Default `"object"` returns the scaled data.
+#' Alternatively, `"terms"` returns the location and scale/covariance estimates,
+#' while `"all"` gives both the scaled data and estimated quantities.
 #' @param ... Other arguments are passed to `cov()`.
 #' @return A vector, matrix or data frame of the same size and class as `object`,
 #' but with numerical variables replaced by scaled versions (renamed if they have been rotated).
@@ -51,8 +54,15 @@ mvscale <- function(
   cov = robustbase::covMcd,
   alpha = 0.9,
   warning = TRUE,
+  what = c("object", "terms", "all"),
   ...
 ) {
+  what <- match.arg(what)
+  what_terms <- FALSE
+  if(what %in% c("terms", "all")){
+    terms_list <- list()
+    what_terms <- TRUE
+  }
   d <- NCOL(object)
   # Check if input is a vector
   is_vec <- d == 1L &&
@@ -91,6 +101,7 @@ mvscale <- function(
   if (!is.null(center)) {
     med <- apply(mat, 2, \(x) center(na.omit(x)))
     mat <- sweep(mat, 2L, med)
+    if(what_terms) terms_list <- c(terms_list, list("center" = med))
   }
   # scale function that ignores missing values
   if (!is.null(scale)) {
@@ -102,7 +113,12 @@ mvscale <- function(
   if (d == 1L) {
     z <- mat / my_scale(mat)
     if (is_vec) {
-      return(as.vector(z))
+      if(what_terms){
+        terms_list <- c(terms_list, list("scale" = my_scale(mat)))
+        if(what == "all") return(c(list("object" = as.vector(z)), terms_list))
+        return(terms_list)
+      }
+      else return(as.vector(z))
     }
   } else if (!is.null(cov)) {
     # Compute covariance matrix from non-missing values
@@ -135,6 +151,7 @@ mvscale <- function(
       }
       warning("Covariance matrix is singular. Adding a small ridge penalty.")
     }
+    if(what_terms) terms_list <- c(terms_list, list("cov" = S, "cov_inverse" = Sinv))
     # Compute scaled and rotated data
     U <- chol(Sinv)
     z <- mat %*% t(U)
@@ -142,7 +159,9 @@ mvscale <- function(
     # Just scale, no rotation
     s <- apply(mat, 2, my_scale)
     z <- sweep(mat, 2L, s, "/")
+    if(what_terms) terms_list <- c(terms_list, list("scale" = s))
   }
+  if(what == "terms") return(terms_list)
   # Convert back to matrix, data frame or tibble if necessary
   idx <- which(numeric_col)
   for (i in seq_along(idx)) {
@@ -152,5 +171,6 @@ mvscale <- function(
   if (!is.null(cov)) {
     names(object)[numeric_col] <- paste0("z", seq(sum(numeric_col)))
   }
+  if(what == "all") return(c(list("object" = object), terms_list))
   return(object)
 }

--- a/R/mvscale.R
+++ b/R/mvscale.R
@@ -26,7 +26,6 @@
 #' @param cov A function to compute the covariance matrix. Set to NULL if no rotation required. `cov()` must either return the matrix directly, or a list containing a matrix named `cov`.
 #' @param alpha When `cov = robustbase::covMcd()`, `alpha` controls the size of the subsets over which the determinant is minimized. Otherwise it is ignored. Set to 0.9 by default.
 #' @param warning Should a warning be issued if non-numeric columns are ignored?
-#' @param what What to return? Default `"object"` returns the scaled data.
 #' Alternatively, `"terms"` returns the location and scale/covariance estimates,
 #' while `"all"` gives both the scaled data and estimated quantities.
 #' @param ... Other arguments are passed to `cov()`.
@@ -57,13 +56,8 @@ mvscale <- function(
   what = c("object", "terms", "all"),
   ...
 ) {
-  what <- match.arg(what)
-  what_terms <- FALSE
-  if(what %in% c("terms", "all")){
-    terms_list <- list()
-    what_terms <- TRUE
-  }
   d <- NCOL(object)
+  terms_list <- list()
   # Check if input is a vector
   is_vec <- d == 1L &&
     !inherits(object, "matrix") &&
@@ -101,7 +95,7 @@ mvscale <- function(
   if (!is.null(center)) {
     med <- apply(mat, 2, \(x) center(na.omit(x)))
     mat <- sweep(mat, 2L, med)
-    if(what_terms) terms_list <- c(terms_list, list("center" = med))
+    terms_list <- c(terms_list, list("center" = med))
   }
   # scale function that ignores missing values
   if (!is.null(scale)) {
@@ -111,14 +105,13 @@ mvscale <- function(
   }
   # Scale
   if (d == 1L) {
-    z <- mat / my_scale(mat)
+    scl <- my_scale(mat)
+    z <- mat / scl
     if (is_vec) {
-      if(what_terms){
-        terms_list <- c(terms_list, list("scale" = my_scale(mat)))
-        if(what == "all") return(c(list("object" = as.vector(z)), terms_list))
-        return(terms_list)
-      }
-      else return(as.vector(z))
+      terms_list <- c(terms_list, list("scale" = scl, "scale_inverse" = 1/scl))
+      z <- as.vector(z)
+      for(a in seq_along(terms_list)) attr(z, which = names(terms_list)[a]) <- terms_list[[a]]
+      return(z)
     }
   } else if (!is.null(cov)) {
     # Compute covariance matrix from non-missing values
@@ -151,7 +144,7 @@ mvscale <- function(
       }
       warning("Covariance matrix is singular. Adding a small ridge penalty.")
     }
-    if(what_terms) terms_list <- c(terms_list, list("cov" = S, "cov_inverse" = Sinv))
+    terms_list <- c(terms_list, list("scale" = S, "scale_inverse" = Sinv))
     # Compute scaled and rotated data
     U <- chol(Sinv)
     z <- mat %*% t(U)
@@ -159,9 +152,8 @@ mvscale <- function(
     # Just scale, no rotation
     s <- apply(mat, 2, my_scale)
     z <- sweep(mat, 2L, s, "/")
-    if(what_terms) terms_list <- c(terms_list, list("scale" = s))
+    terms_list <- c(terms_list, list("scale" = s, scale_inverse = 1/s))
   }
-  if(what == "terms") return(terms_list)
   # Convert back to matrix, data frame or tibble if necessary
   idx <- which(numeric_col)
   for (i in seq_along(idx)) {
@@ -171,6 +163,6 @@ mvscale <- function(
   if (!is.null(cov)) {
     names(object)[numeric_col] <- paste0("z", seq(sum(numeric_col)))
   }
-  if(what == "all") return(c(list("object" = object), terms_list))
+  for(a in seq_along(terms_list)) attr(object, which = names(terms_list)[a]) <- terms_list[[a]]
   return(object)
 }

--- a/man/mvscale.Rd
+++ b/man/mvscale.Rd
@@ -11,6 +11,7 @@ mvscale(
   cov = robustbase::covMcd,
   alpha = 0.9,
   warning = TRUE,
+  what = c("object", "terms", "all"),
   ...
 )
 }
@@ -29,6 +30,10 @@ to NULL if no centering is required.}
 \item{alpha}{When \code{cov = robustbase::covMcd()}, \code{alpha} controls the size of the subsets over which the determinant is minimized. Otherwise it is ignored. Set to 0.9 by default.}
 
 \item{warning}{Should a warning be issued if non-numeric columns are ignored?}
+
+\item{what}{What to return? Default \code{"object"} returns the scaled data.
+Alternatively, \code{"terms"} returns the location and scale/covariance estimates,
+while \code{"all"} gives both the scaled data and estimated quantities.}
 
 \item{...}{Other arguments are passed to \code{cov()}.}
 }

--- a/man/mvscale.Rd
+++ b/man/mvscale.Rd
@@ -29,9 +29,7 @@ to NULL if no centering is required.}
 
 \item{alpha}{When \code{cov = robustbase::covMcd()}, \code{alpha} controls the size of the subsets over which the determinant is minimized. Otherwise it is ignored. Set to 0.9 by default.}
 
-\item{warning}{Should a warning be issued if non-numeric columns are ignored?}
-
-\item{what}{What to return? Default \code{"object"} returns the scaled data.
+\item{warning}{Should a warning be issued if non-numeric columns are ignored?
 Alternatively, \code{"terms"} returns the location and scale/covariance estimates,
 while \code{"all"} gives both the scaled data and estimated quantities.}
 

--- a/tests/testthat/test_mvscale.R
+++ b/tests/testthat/test_mvscale.R
@@ -23,9 +23,9 @@ test_that("mvscale centres vector to approximately zero median", {
 })
 
 test_that("mvscale terms agrees with results from default arguments", {
-  z <- mvscale(v_num, warning = FALSE, what = "terms")
-  expect_equal(median(v_num), z$center, tolerance = 1e-6)
-  expect_equal(robustbase::s_Qn(v_num), z$scale, tolerance = 1e-6)
+  z <- mvscale(v_num, warning = FALSE)
+  expect_equal(median(v_num), attr(z, "center"), tolerance = 1e-6)
+  expect_equal(robustbase::s_Qn(v_num), attr(z, "scale"), tolerance = 1e-6)
 })
 
 test_that("mvscale errors on non-numeric vector", {
@@ -105,15 +105,15 @@ test_that("mvscale with cov = NULL scales each column by s_Qn", {
 })
 
 test_that("mvscale with cov = NULL scales each column by s_Qn", {
-  z <- mvscale(mat2, cov = NULL, warning = FALSE, what = "terms")
+  z <- mvscale(mat2, cov = NULL, warning = FALSE)
   col_scales <- apply(mat2, 2, robustbase::s_Qn)
-  expect_equal(z$scale, col_scales, tolerance = 0.01)
+  expect_equal(attr(z, "scale"), col_scales, tolerance = 0.01)
 })
 
 test_that("mvscale with cov = NULL centers each column by median", {
-  z <- mvscale(mat2, cov = NULL, warning = FALSE, what = "terms")
+  z <- mvscale(mat2, cov = NULL, warning = FALSE)
   col_centers <- apply(mat2, 2, median)
-  expect_equal(z$center, col_centers, tolerance = 0.01)
+  expect_equal(attr(z, "center"), col_centers, tolerance = 0.01)
 })
 
 # cov = stats::cov (non-robust rotation) --------------------------------

--- a/tests/testthat/test_mvscale.R
+++ b/tests/testthat/test_mvscale.R
@@ -22,6 +22,12 @@ test_that("mvscale centres vector to approximately zero median", {
   expect_equal(median(z), 0, tolerance = 1e-6)
 })
 
+test_that("mvscale terms agrees with results from default arguments", {
+  z <- mvscale(v_num, warning = FALSE, what = "terms")
+  expect_equal(median(v_num), z$center, tolerance = 1e-6)
+  expect_equal(robustbase::s_Qn(v_num), z$scale, tolerance = 1e-6)
+})
+
 test_that("mvscale errors on non-numeric vector", {
   expect_error(mvscale(letters), "numeric")
 })
@@ -96,6 +102,18 @@ test_that("mvscale with cov = NULL scales each column by s_Qn", {
   # After centering and scaling by s_Qn, s_Qn of each column should be ~1
   col_scales <- apply(z, 2, robustbase::s_Qn)
   expect_equal(col_scales, c(1, 1), tolerance = 0.01)
+})
+
+test_that("mvscale with cov = NULL scales each column by s_Qn", {
+  z <- mvscale(mat2, cov = NULL, warning = FALSE, what = "terms")
+  col_scales <- apply(mat2, 2, robustbase::s_Qn)
+  expect_equal(z$scale, col_scales, tolerance = 0.01)
+})
+
+test_that("mvscale with cov = NULL centers each column by median", {
+  z <- mvscale(mat2, cov = NULL, warning = FALSE, what = "terms")
+  col_centers <- apply(mat2, 2, median)
+  expect_equal(z$center, col_centers, tolerance = 0.01)
 })
 
 # cov = stats::cov (non-robust rotation) --------------------------------


### PR DESCRIPTION
Adding the option for `mvscale` to return estimates of location and scale. Default returns the scaled object, while `what = "terms"` gives `list(center = ..., scale = ...)` in case `cov = NULL` and `list(center = ..., cov = ..., cov_inverse = ...)` when `cov` is non-`NULL`. If `what = "all"`, the lists also includes `object = ...` as the first element.