### PR TITLE
Update for mlpack 4.8.0 API change

### DIFF
--- a/R/kde_bandwidth.R
+++ b/R/kde_bandwidth.R
@@ -47,7 +47,7 @@ kde_bandwidth <- function(
     }
   }
   if (method == "lookout") {
-    if (packageVersion("mlpack") < "4.8.0")
+    if (packageVersion("mlpack") < "4.8.0") {
       death_radi <- mlpack::emst(mvscale(as.matrix(data)))$output[, 3]
     } else {
       death_radi <- mlpack::emst(mvscale(as.matrix(data)))[, 3]

--- a/R/kde_bandwidth.R
+++ b/R/kde_bandwidth.R
@@ -47,7 +47,11 @@ kde_bandwidth <- function(
     }
   }
   if (method == "lookout") {
-    death_radi <- mlpack::emst(mvscale(as.matrix(data)))$output[, 3]
+    if (packageVersion("mlpack") < "4.8.0")
+      death_radi <- mlpack::emst(mvscale(as.matrix(data)))$output[, 3]
+    } else {
+      death_radi <- mlpack::emst(mvscale(as.matrix(data)))[, 3]
+    }
     cc <- unname(quantile(death_radi, probs = 0.98, type = 8L))
   } else {
     cc <- (4 / (n * (d + 2)))^(2 / (d + 4))


### PR DESCRIPTION
Hi there,

I'm glad you found mlpack useful in your work here. We just did a release for version 4.8.0 and due to a little bit of an oversight, the API for mlpack::emst ended up changing (normally we try to keep API-changing releases as major release bumps). I would say it's for the better: instead of awkwardly returning a one-element list, it now returns just the output matrix itself.

Anyway, this diff allows compatibility with both old and new versions. Note that I did not test this, but it should work. You should definitely test it on your end.

If you prefer, you could just remove the $output instead and we can submit updated versions of both weird and mlpack 4.8.0 to CRAN at the same time; let me know what you think.

Thanks so much!
